### PR TITLE
Use setuid as non-root user when in Docker

### DIFF
--- a/lib/Oberth/Launch.pm
+++ b/lib/Oberth/Launch.pm
@@ -35,6 +35,7 @@ use CLI::Osprey;
 use ShellQuote::Any;
 use File::Path qw(make_path);
 use File::Which;
+use Safe::Isa;
 
 use Oberth::Manoeuvre::Common::Setup;
 
@@ -193,6 +194,7 @@ method clone_git($url, $branch = 'master') {
 			$url,
 			$path) == 0
 		or die "Could not clone $url @ $branch";
+		$self->platform->$_call_if_can( process_git_path => $path );
 	}
 
 	return $path;

--- a/lib/Oberth/Launch/Runner/Default.pm
+++ b/lib/Oberth/Launch/Runner/Default.pm
@@ -48,7 +48,8 @@ sub _system_with_env {
 
 method _system_with_env_args( $runnable ) {
 	my $env = $runnable->environment->environment_hash;
-	my $user_args = { user => $> , group => $) };
+	my $user_args = { user => $> , group => (split(' ', $) ))[0] };
+
 	if( ! $runnable->admin_privilege && Oberth::Launch::System::Docker->is_inside_docker ) {
 		# become a non-root user
 		$user_args->{group} = '1000';

--- a/lib/Oberth/Launch/Runner/Default.pm
+++ b/lib/Oberth/Launch/Runner/Default.pm
@@ -12,6 +12,8 @@ use IO::Async::Loop;
 use IO::Async::Function;
 use IO::Async::Timer::Periodic;
 
+use Oberth::Launch::System::Docker;
+
 lazy loop => method() {
 	my $loop = IO::Async::Loop->new;
 
@@ -29,19 +31,35 @@ lazy system_function => method() {
 };
 
 sub _system_with_env {
-	my ( $env, $command, $pwd ) = @_;
+	my ( $env, $command, $pwd, $user_args ) = @_;
 
 	use File::chdir;
 	local $CWD = $pwd;
 	local %ENV = %{ $env };
+
+	local $( = $user_args->{group};
+	local $) = $(;
+
+	local $< = $user_args->{user};
+	local $> = $<;
+
 	my $exit = CORE::system( @{ $command } );
 }
 
 method _system_with_env_args( $runnable ) {
+	my $env = $runnable->environment->environment_hash;
+	my $user_args = { user => $> , group => $) };
+	if( ! $runnable->admin_privilege && Oberth::Launch::System::Docker->is_inside_docker ) {
+		# become a non-root user
+		$user_args->{group} = '1000';
+		$user_args->{user} = 1000;
+		$env->{HOME} = '/home/notroot';
+	}
 	return (
-		$runnable->environment->environment_hash,
+		$env,
 		$runnable->command,
 		$CWD,
+		$user_args,
 	);
 }
 

--- a/lib/Oberth/Launch/System/Debian/Meson.pm
+++ b/lib/Oberth/Launch/System/Debian/Meson.pm
@@ -50,11 +50,18 @@ method setup() {
 				environment => $self->environment,
 			)
 		) for(
-			[ qw(apt-get install -y --no-install-recommends python3-pip) ],
 			[ qw(pip3 install --user -U setuptools wheel) ],
 			[ qw(pip3 install --user -U meson) ],
 		);
 	}
+}
+
+method install_pip3_apt( $apt ) {
+	$self->runner->system(
+		$apt->install_packages_command(
+			Oberth::Launch::RepoPackage::APT->new( name => 'python3-pip' )
+		)
+	);
 }
 
 1;

--- a/lib/Oberth/Launch/System/Docker.pm
+++ b/lib/Oberth/Launch/System/Docker.pm
@@ -1,0 +1,13 @@
+use Modern::Perl;
+package Oberth::Launch::System::Docker;
+# ABSTRACT: Helper for Docker
+
+use Mu;
+use Oberth::Manoeuvre::Common::Setup;
+
+classmethod is_inside_docker() {
+	my $cgroup = path('/proc/1/cgroup');
+	return -f $cgroup  && $cgroup->slurp_utf8 =~ m,/(lxc|docker)/[0-9a-f]{64},s;
+}
+
+1;


### PR DESCRIPTION
This allows for building and testing code as a non-root user which is
how most code will be run. Furthermore, certain code does not run as the
root user for security reasons (e.g., sandboxed Chromium which requires
`--no-sandbox` to run under a root user).

Connects with <https://github.com/oberth-manoeuvre/p5-Oberth-Launch/issues/45>.